### PR TITLE
Support for device_class and should_poll

### DIFF
--- a/custom_components/templatesensor/__init__.py
+++ b/custom_components/templatesensor/__init__.py
@@ -4,16 +4,15 @@ Component to integrate with blueprint.
 For more details about this component, please refer to
 https://github.com/custom-components/blueprint
 """
+import logging
 import os
 from datetime import timedelta
-import logging
-import voluptuous as vol
+
 from homeassistant import config_entries
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.util import Throttle
 
-from .const import DOMAIN_DATA, DOMAIN, ISSUE_URL, PLATFORMS, REQUIRED_FILES, VERSION
+from .const import DOMAIN, DOMAIN_DATA, ISSUE_URL, PLATFORMS, REQUIRED_FILES, VERSION
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 

--- a/custom_components/templatesensor/config_flow.py
+++ b/custom_components/templatesensor/config_flow.py
@@ -46,6 +46,7 @@ class TemplateSensorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         icon = ""
         unit = ""
         device_class = ""
+        should_poll = True
 
         if user_input is not None:
             if "name" in user_input:
@@ -58,6 +59,8 @@ class TemplateSensorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 unit = user_input["unit"]
             if "device_class" in user_input:
                 device_class = user_input["device_class"]
+            if "should_poll" in user_input:
+                should_poll = user_input["should_poll"]
 
         data_schema = vol.Schema(
             {
@@ -68,6 +71,7 @@ class TemplateSensorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional("device_class", default=device_class): vol.In(
                     DEVICE_CLASSES
                 ),
+                vol.Optional("should_poll", default=should_poll): bool,
             }
         )
         return self.async_show_form(
@@ -130,6 +134,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         "suggested_value": self.config_entry.options.get("device_class")
                     },
                 ): vol.In(DEVICE_CLASSES),
+                vol.Optional("should_poll", default=self.config_entry.options.get("should_poll", True)): bool,
             }
         )
 

--- a/custom_components/templatesensor/config_flow.py
+++ b/custom_components/templatesensor/config_flow.py
@@ -1,13 +1,12 @@
 """Adds config flow for templatesensor."""
-from collections import OrderedDict
 import logging
-import voluptuous as vol
 
+import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.helpers import template as templater
 
-from .const import DOMAIN
+from .const import DEVICE_CLASSES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +27,9 @@ class TemplateSensorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             valid = await self._validate_template(user_input["template"])
             if valid:
-                return self.async_create_entry(title=user_input["name"], data=user_input)
+                return self.async_create_entry(
+                    title=user_input["name"], data=user_input
+                )
             else:
                 self._errors["base"] = "template"
 
@@ -44,6 +45,7 @@ class TemplateSensorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         template = ""
         icon = ""
         unit = ""
+        device_class = ""
 
         if user_input is not None:
             if "name" in user_input:
@@ -54,14 +56,22 @@ class TemplateSensorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 icon = user_input["icon"]
             if "unit" in user_input:
                 unit = user_input["unit"]
+            if "device_class" in user_input:
+                device_class = user_input["device_class"]
 
-        data_schema = OrderedDict()
-        data_schema[vol.Required("name", default=name)] = str
-        data_schema[vol.Required("template", default=template)] = str
-        data_schema[vol.Optional("icon", default=icon)] = str
-        data_schema[vol.Optional("unit", default=unit)] = str
+        data_schema = vol.Schema(
+            {
+                vol.Required("name", default=name): str,
+                vol.Required("template", default=template): str,
+                vol.Optional("icon", default=icon): str,
+                vol.Optional("unit", default=unit): str,
+                vol.Optional("device_class", default=device_class): vol.In(
+                    DEVICE_CLASSES
+                ),
+            }
+        )
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(data_schema), errors=self._errors
+            step_id="user", data_schema=data_schema, errors=self._errors
         )
 
     @staticmethod
@@ -94,15 +104,33 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        data_schema = {
-            vol.Required("name", default=self.config_entry.options.get("name")): str,
-            vol.Required("template", default=self.config_entry.options.get("template")): str,
-            vol.Optional(
-                "icon", description={"suggested_value": self.config_entry.options.get("icon")}
-            ): str,
-            vol.Optional(
-                "unit", description={"suggested_value": self.config_entry.options.get("unit")}
-            ): str,
-        }
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    "name", default=self.config_entry.options.get("name")
+                ): str,
+                vol.Required(
+                    "template", default=self.config_entry.options.get("template")
+                ): str,
+                vol.Optional(
+                    "icon",
+                    description={
+                        "suggested_value": self.config_entry.options.get("icon")
+                    },
+                ): str,
+                vol.Optional(
+                    "unit",
+                    description={
+                        "suggested_value": self.config_entry.options.get("unit")
+                    },
+                ): str,
+                vol.Optional(
+                    "device_class",
+                    description={
+                        "suggested_value": self.config_entry.options.get("device_class")
+                    },
+                ): vol.In(DEVICE_CLASSES),
+            }
+        )
 
-        return self.async_show_form(step_id="user", data_schema=vol.Schema(data_schema))
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/custom_components/templatesensor/const.py
+++ b/custom_components/templatesensor/const.py
@@ -1,8 +1,10 @@
 """Constants for templatesensor."""
-# Base component constants
+from homeassistant.components.sensor import DEVICE_CLASSES
+
+DEVICE_CLASSES = {device_class: device_class for device_class in DEVICE_CLASSES}
 DOMAIN = "templatesensor"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.1.3"
+VERSION = "0.2.0"
 PLATFORMS = ["sensor"]
 REQUIRED_FILES = [
     "translations/en.json",

--- a/custom_components/templatesensor/manifest.json
+++ b/custom_components/templatesensor/manifest.json
@@ -1,12 +1,13 @@
 {
-  "version": "0.1.3",
+  "version": "0.2.0",
   "domain": "templatesensor",
   "name": "UI Template sensor configuration",
   "documentation": "https://github.com/custom-components/templatesensor",
   "dependencies": [],
   "config_flow": true,
   "codeowners": [
-    "@ludeeus"
+    "@ludeeus",
+    "@notabene00"
   ],
   "requirements": []
 }

--- a/custom_components/templatesensor/sensor.py
+++ b/custom_components/templatesensor/sensor.py
@@ -1,6 +1,6 @@
 """Sensor platform for templatesensor."""
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers import template as templater
+from homeassistant.helpers.entity import Entity
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -49,3 +49,8 @@ class CustomTemplateSensor(Entity):
     def icon(self):
         """Return the icon of the sensor."""
         return self.config.options.get("icon")
+
+    @property
+    def device_class(self):
+        """Return the device_class of the sensor."""
+        return self.config.options.get("device_class")

--- a/custom_components/templatesensor/sensor.py
+++ b/custom_components/templatesensor/sensor.py
@@ -16,6 +16,10 @@ class CustomTemplateSensor(Entity):
         self.config = config
         self._state = None
 
+    @property
+    def should_poll(self):
+        return self.config.data.get("should_poll", True)
+
     async def async_update(self):
         """Update the sensor."""
         try:

--- a/custom_components/templatesensor/translations/en.json
+++ b/custom_components/templatesensor/translations/en.json
@@ -10,7 +10,8 @@
                     "template": "Template*",
                     "icon": "Icon",
                     "unit": "Unit of measurement",
-                    "device_class": "Device class"
+                    "device_class": "Device class",
+                    "should_poll": "Should poll"
                 }
             }
         },
@@ -29,7 +30,8 @@
                     "template": "Template*",
                     "icon": "Icon",
                     "unit": "Unit of measurement",
-                    "device_class": "Device class"
+                    "device_class": "Device class",
+                    "should_poll": "Should poll"
                 }
             }
         }

--- a/custom_components/templatesensor/translations/en.json
+++ b/custom_components/templatesensor/translations/en.json
@@ -9,7 +9,8 @@
                     "name": "Name*",
                     "template": "Template*",
                     "icon": "Icon",
-                    "unit": "Unit of measurement"
+                    "unit": "Unit of measurement",
+                    "device_class": "Device class"
                 }
             }
         },
@@ -27,7 +28,8 @@
                     "name": "Name*",
                     "template": "Template*",
                     "icon": "Icon",
-                    "unit": "Unit of measurement"
+                    "unit": "Unit of measurement",
+                    "device_class": "Device class"
                 }
             }
         }


### PR DESCRIPTION
Now you can select `device_class` and `should_poll` for sensor while creating 

Removed unused imports
Code formatted with `isort` and `black`
`0.2.0` version according to SV

`DEVICE_CLASSES` taken from device classes constants supported by sensors 
so they'll be actual if list will change

`should_poll` default for sensors that haven't such property is `True` so that is taken into account too
in the edit window it is `True` for previously created (they hasn't `should_poll` key in the config data) sensors
and it's still `True` for these sensors in their configuration as the fallback for missing `should_poll` key is `True` there too